### PR TITLE
feat: 各スキルで生成した PDF を Google Drive へ自動アップロードする機能を追加

### DIFF
--- a/.claude/skills/ai-news-summary/SKILL.md
+++ b/.claude/skills/ai-news-summary/SKILL.md
@@ -63,7 +63,7 @@ rm -f tmp/raw_articles.json tmp/summarized_articles.json
 まず、必要なパッケージがインストールされているか確認してください：
 
 ```bash
-pip install requests beautifulsoup4 feedparser reportlab fake-useragent
+pip install requests beautifulsoup4 feedparser reportlab fake-useragent google-api-python-client google-auth google-auth-oauthlib
 ```
 
 ### 3. ニュースソースの読み込み
@@ -125,6 +125,16 @@ PDFファイルのパスとサマリーをSlackに投稿してください：
 ```
 
 **注意**: Slack Webhook URLは `post_slack.py` 内の `WEBHOOK_URL` 変数を設定してください。
+
+### 8. Google Driveアップロード
+
+PDFファイルを Google Drive の指定フォルダにアップロードしてください：
+
+```bash
+./.claude/skills/ai-news-summary/scripts/upload_gdrive.py output/ai-news-YYYY-MM-DD.pdf
+```
+
+**注意**: Google Drive の認証情報 (OAuth クライアントシークレットのパス、フォルダ ID) は `config/secrets.json` または環境変数で設定してください。初回実行時はブラウザで Google アカウント認証が必要です。同名ファイルが既に存在する場合は上書きされます。
 
 ## 出力
 

--- a/.claude/skills/ai-news-summary/SKILL.md
+++ b/.claude/skills/ai-news-summary/SKILL.md
@@ -124,7 +124,7 @@ PDFファイルのパスとサマリーをSlackに投稿してください：
 ./.claude/skills/ai-news-summary/scripts/post_slack.py output/ai-news-YYYY-MM-DD.pdf "本日のAIニュース要約です"
 ```
 
-**注意**: Slack Webhook URLは `post_slack.py` 内の `WEBHOOK_URL` 変数を設定してください。
+**注意**: Slack 認証情報は `secrets/settings.json` または環境変数で設定してください。
 
 ### 8. Google Driveアップロード
 
@@ -134,7 +134,7 @@ PDFファイルを Google Drive の指定フォルダにアップロードして
 ./.claude/skills/ai-news-summary/scripts/upload_gdrive.py output/ai-news-YYYY-MM-DD.pdf
 ```
 
-**注意**: Google Drive の認証情報 (OAuth クライアントシークレットのパス、フォルダ ID) は `config/secrets.json` または環境変数で設定してください。初回実行時はブラウザで Google アカウント認証が必要です。同名ファイルが既に存在する場合は上書きされます。
+**注意**: Google Drive の認証情報 (OAuth クライアントシークレットのパス、フォルダ ID) は `secrets/settings.json` または環境変数で設定してください。初回実行時はブラウザで Google アカウント認証が必要です。同名ファイルが既に存在する場合は上書きされます。
 
 ## 出力
 

--- a/.claude/skills/ai-news-summary/config/secrets.example.json
+++ b/.claude/skills/ai-news-summary/config/secrets.example.json
@@ -1,5 +1,7 @@
 {
   "slack_bot_token": "xoxb-YOUR-BOT-TOKEN-HERE",
   "slack_webhook_url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
-  "slack_channel_id": "C0YOUR_CHANNEL_ID"
+  "slack_channel_id": "C0YOUR_CHANNEL_ID",
+  "gdrive_client_secret": "secret/client_secret.apps.googleusercontent.com.json",
+  "gdrive_folder_id": "YOUR_GOOGLE_DRIVE_FOLDER_ID"
 }

--- a/.claude/skills/ai-news-summary/config/secrets.example.json
+++ b/.claude/skills/ai-news-summary/config/secrets.example.json
@@ -1,7 +1,0 @@
-{
-  "slack_bot_token": "xoxb-YOUR-BOT-TOKEN-HERE",
-  "slack_webhook_url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
-  "slack_channel_id": "C0YOUR_CHANNEL_ID",
-  "gdrive_client_secret": "secret/client_secret.apps.googleusercontent.com.json",
-  "gdrive_folder_id": "YOUR_GOOGLE_DRIVE_FOLDER_ID"
-}

--- a/.claude/skills/ai-news-summary/scripts/upload_gdrive.py
+++ b/.claude/skills/ai-news-summary/scripts/upload_gdrive.py
@@ -1,0 +1,165 @@
+#!/Users/tamaco/Desktop/work/general/.venv/bin/python3
+"""Google Driveアップロードスクリプト（AWSブログ用）"""
+
+import json
+import logging
+import os
+import sys
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+
+# ロギング設定
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s: %(message)s',
+    stream=sys.stderr
+)
+logger = logging.getLogger(__name__)
+
+# パス設定
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(SCRIPT_DIR)
+SECRETS_PATH = os.path.join(SKILL_DIR, 'config', 'secrets.json')
+
+SCOPES = ['https://www.googleapis.com/auth/drive.file']
+
+
+def _load_json(path, default=None):
+    """JSONファイルを読み込む"""
+    if not os.path.exists(path):
+        return default or {}
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        logger.warning(f"{path}: {e}")
+        return default or {}
+
+
+def _get_env_or(key, default=''):
+    """環境変数を取得、なければデフォルト"""
+    return os.environ.get(key) or default
+
+
+def load_secrets():
+    """秘匿情報を読み込む（環境変数優先）"""
+    if not os.path.exists(SECRETS_PATH):
+        logger.warning(f"{SECRETS_PATH} not found. Using environment variables.")
+    secrets = _load_json(SECRETS_PATH)
+    result = {
+        'client_secret': _get_env_or(
+            'GDRIVE_CLIENT_SECRET',
+            secrets.get('gdrive_client_secret', '')
+        ),
+        'folder_id': _get_env_or(
+            'GDRIVE_FOLDER_ID',
+            secrets.get('gdrive_folder_id', '')
+        ),
+    }
+    if not result['client_secret']:
+        logger.error("Google Drive OAuth client secret is not configured.")
+        logger.error(f"  Set GDRIVE_CLIENT_SECRET env var or")
+        logger.error(f"  add gdrive_client_secret to {SECRETS_PATH}")
+    if not result['folder_id']:
+        logger.error("Google Drive folder ID is not configured.")
+        logger.error(f"  Set GDRIVE_FOLDER_ID env var or")
+        logger.error(f"  add gdrive_folder_id to {SECRETS_PATH}")
+    return result
+
+
+def get_drive_service(client_secret_path):
+    """OAuth 2.0認証でGoogle Drive APIサービスを構築"""
+    token_path = os.path.join(os.path.dirname(client_secret_path), 'gdrive_token.json')
+    creds = None
+
+    # 保存済みトークンがあれば読み込む
+    if os.path.exists(token_path):
+        creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+
+    # トークンがない or 期限切れの場合
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            logger.info("Refreshing access token...")
+            creds.refresh(Request())
+        else:
+            logger.info("Opening browser for authorization...")
+            flow = InstalledAppFlow.from_client_secrets_file(client_secret_path, SCOPES)
+            creds = flow.run_local_server(port=0)
+
+        # トークンを保存
+        with open(token_path, 'w') as f:
+            f.write(creds.to_json())
+        logger.info(f"Token saved to {token_path}")
+
+    return build('drive', 'v3', credentials=creds)
+
+
+def find_existing_file(service, name, folder_id):
+    """フォルダ内の同名ファイルを検索"""
+    query = (
+        f"name = '{name}' and '{folder_id}' in parents and trashed = false"
+    )
+    results = service.files().list(
+        q=query, fields='files(id, name)', pageSize=1
+    ).execute()
+    files = results.get('files', [])
+    return files[0]['id'] if files else None
+
+
+def upload_file(service, path, folder_id):
+    """ファイルをGoogle Driveにアップロード（同名ファイルがあれば上書き）"""
+    name = os.path.basename(path)
+    media = MediaFileUpload(path, mimetype='application/pdf', resumable=True)
+
+    existing_id = find_existing_file(service, name, folder_id)
+
+    if existing_id:
+        logger.info(f"Updating existing file: {name} (id: {existing_id})")
+        file = service.files().update(
+            fileId=existing_id,
+            media_body=media,
+        ).execute()
+    else:
+        logger.info(f"Uploading new file: {name}")
+        metadata = {
+            'name': name,
+            'parents': [folder_id],
+        }
+        file = service.files().create(
+            body=metadata,
+            media_body=media,
+            fields='id, name, webViewLink',
+        ).execute()
+
+    logger.info(f"Done! File ID: {file.get('id')}")
+    web_link = file.get('webViewLink')
+    if web_link:
+        logger.info(f"Link: {web_link}")
+    return file
+
+
+def main():
+    if len(sys.argv) < 2:
+        logger.error("Usage: upload_gdrive.py <pdf_path>")
+        sys.exit(1)
+
+    pdf_path = sys.argv[1]
+    if not os.path.exists(pdf_path):
+        logger.error(f"File not found: {pdf_path}")
+        sys.exit(1)
+
+    secrets = load_secrets()
+    if not secrets['client_secret'] or not secrets['folder_id']:
+        sys.exit(1)
+
+    service = get_drive_service(secrets['client_secret'])
+    upload_file(service, pdf_path, secrets['folder_id'])
+    logger.info("Success!")
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/aws-blog-summary/SKILL.md
+++ b/.claude/skills/aws-blog-summary/SKILL.md
@@ -62,7 +62,7 @@ rm -f tmp/aws_raw_articles.json tmp/aws_summarized_articles.json
 まず、必要なパッケージがインストールされているか確認してください：
 
 ```bash
-pip install requests beautifulsoup4 feedparser reportlab fake-useragent
+pip install requests beautifulsoup4 feedparser reportlab fake-useragent google-api-python-client google-auth google-auth-oauthlib
 ```
 
 ### 3. ニュース取得
@@ -117,6 +117,16 @@ PDFファイルとサマリーをSlackに投稿してください：
 ```
 
 **注意**: Slack認証情報は `config/secrets.json` または環境変数で設定してください。
+
+### 7. Google Driveアップロード
+
+PDFファイルを Google Drive の指定フォルダにアップロードしてください：
+
+```bash
+./.claude/skills/aws-blog-summary/scripts/upload_gdrive.py output/aws-blog-YYYY-MM-DD.pdf
+```
+
+**注意**: Google Drive の認証情報 (OAuth クライアントシークレットのパス、フォルダ ID) は `config/secrets.json` または環境変数で設定してください。初回実行時はブラウザで Google アカウント認証が必要です。同名ファイルが既に存在する場合は上書きされます。
 
 ## 出力
 

--- a/.claude/skills/aws-blog-summary/SKILL.md
+++ b/.claude/skills/aws-blog-summary/SKILL.md
@@ -116,7 +116,7 @@ PDFファイルとサマリーをSlackに投稿してください：
 ./.claude/skills/aws-blog-summary/scripts/post_slack.py output/aws-blog-YYYY-MM-DD.pdf "本日のAWSブログ要約です" tmp/aws_summarized_articles.json
 ```
 
-**注意**: Slack認証情報は `config/secrets.json` または環境変数で設定してください。
+**注意**: Slack 認証情報は `secrets/settings.json` または環境変数で設定してください。
 
 ### 7. Google Driveアップロード
 
@@ -126,7 +126,7 @@ PDFファイルを Google Drive の指定フォルダにアップロードして
 ./.claude/skills/aws-blog-summary/scripts/upload_gdrive.py output/aws-blog-YYYY-MM-DD.pdf
 ```
 
-**注意**: Google Drive の認証情報 (OAuth クライアントシークレットのパス、フォルダ ID) は `config/secrets.json` または環境変数で設定してください。初回実行時はブラウザで Google アカウント認証が必要です。同名ファイルが既に存在する場合は上書きされます。
+**注意**: Google Drive の認証情報 (OAuth クライアントシークレットのパス、フォルダ ID) は `secrets/settings.json` または環境変数で設定してください。初回実行時はブラウザで Google アカウント認証が必要です。同名ファイルが既に存在する場合は上書きされます。
 
 ## 出力
 
@@ -136,7 +136,7 @@ PDFファイルを Google Drive の指定フォルダにアップロードして
 ## トラブルシューティング
 
 - PDFのフォントが表示されない場合: macOS以外の環境では `generate_pdf.py` 内のフォントパスを変更してください
-- Slack投稿が失敗する場合: `config/secrets.json` の設定を確認してください
+- Slack投稿が失敗する場合: `secrets/settings.json` の設定を確認してください
 - 記事が取得できない場合: AWSブログのRSSフィードが変更された可能性があります
 
 ## 補足事項

--- a/.claude/skills/aws-blog-summary/config/secrets.example.json
+++ b/.claude/skills/aws-blog-summary/config/secrets.example.json
@@ -1,5 +1,7 @@
 {
   "slack_bot_token": "xoxb-YOUR-BOT-TOKEN-HERE",
   "slack_webhook_url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
-  "slack_channel_id": "C0YOUR_CHANNEL_ID"
+  "slack_channel_id": "C0YOUR_CHANNEL_ID",
+  "gdrive_client_secret": "secret/client_secret.apps.googleusercontent.com.json",
+  "gdrive_folder_id": "YOUR_GOOGLE_DRIVE_FOLDER_ID"
 }

--- a/.claude/skills/aws-blog-summary/config/secrets.example.json
+++ b/.claude/skills/aws-blog-summary/config/secrets.example.json
@@ -1,7 +1,0 @@
-{
-  "slack_bot_token": "xoxb-YOUR-BOT-TOKEN-HERE",
-  "slack_webhook_url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
-  "slack_channel_id": "C0YOUR_CHANNEL_ID",
-  "gdrive_client_secret": "secret/client_secret.apps.googleusercontent.com.json",
-  "gdrive_folder_id": "YOUR_GOOGLE_DRIVE_FOLDER_ID"
-}

--- a/.claude/skills/aws-blog-summary/scripts/upload_gdrive.py
+++ b/.claude/skills/aws-blog-summary/scripts/upload_gdrive.py
@@ -1,0 +1,165 @@
+#!/Users/tamaco/Desktop/work/general/.venv/bin/python3
+"""Google Driveアップロードスクリプト（AWSブログ用）"""
+
+import json
+import logging
+import os
+import sys
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+
+# ロギング設定
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s: %(message)s',
+    stream=sys.stderr
+)
+logger = logging.getLogger(__name__)
+
+# パス設定
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(SCRIPT_DIR)
+SECRETS_PATH = os.path.join(SKILL_DIR, 'config', 'secrets.json')
+
+SCOPES = ['https://www.googleapis.com/auth/drive.file']
+
+
+def _load_json(path, default=None):
+    """JSONファイルを読み込む"""
+    if not os.path.exists(path):
+        return default or {}
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        logger.warning(f"{path}: {e}")
+        return default or {}
+
+
+def _get_env_or(key, default=''):
+    """環境変数を取得、なければデフォルト"""
+    return os.environ.get(key) or default
+
+
+def load_secrets():
+    """秘匿情報を読み込む（環境変数優先）"""
+    if not os.path.exists(SECRETS_PATH):
+        logger.warning(f"{SECRETS_PATH} not found. Using environment variables.")
+    secrets = _load_json(SECRETS_PATH)
+    result = {
+        'client_secret': _get_env_or(
+            'GDRIVE_CLIENT_SECRET',
+            secrets.get('gdrive_client_secret', '')
+        ),
+        'folder_id': _get_env_or(
+            'GDRIVE_FOLDER_ID',
+            secrets.get('gdrive_folder_id', '')
+        ),
+    }
+    if not result['client_secret']:
+        logger.error("Google Drive OAuth client secret is not configured.")
+        logger.error(f"  Set GDRIVE_CLIENT_SECRET env var or")
+        logger.error(f"  add gdrive_client_secret to {SECRETS_PATH}")
+    if not result['folder_id']:
+        logger.error("Google Drive folder ID is not configured.")
+        logger.error(f"  Set GDRIVE_FOLDER_ID env var or")
+        logger.error(f"  add gdrive_folder_id to {SECRETS_PATH}")
+    return result
+
+
+def get_drive_service(client_secret_path):
+    """OAuth 2.0認証でGoogle Drive APIサービスを構築"""
+    token_path = os.path.join(os.path.dirname(client_secret_path), 'gdrive_token.json')
+    creds = None
+
+    # 保存済みトークンがあれば読み込む
+    if os.path.exists(token_path):
+        creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+
+    # トークンがない or 期限切れの場合
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            logger.info("Refreshing access token...")
+            creds.refresh(Request())
+        else:
+            logger.info("Opening browser for authorization...")
+            flow = InstalledAppFlow.from_client_secrets_file(client_secret_path, SCOPES)
+            creds = flow.run_local_server(port=0)
+
+        # トークンを保存
+        with open(token_path, 'w') as f:
+            f.write(creds.to_json())
+        logger.info(f"Token saved to {token_path}")
+
+    return build('drive', 'v3', credentials=creds)
+
+
+def find_existing_file(service, name, folder_id):
+    """フォルダ内の同名ファイルを検索"""
+    query = (
+        f"name = '{name}' and '{folder_id}' in parents and trashed = false"
+    )
+    results = service.files().list(
+        q=query, fields='files(id, name)', pageSize=1
+    ).execute()
+    files = results.get('files', [])
+    return files[0]['id'] if files else None
+
+
+def upload_file(service, path, folder_id):
+    """ファイルをGoogle Driveにアップロード（同名ファイルがあれば上書き）"""
+    name = os.path.basename(path)
+    media = MediaFileUpload(path, mimetype='application/pdf', resumable=True)
+
+    existing_id = find_existing_file(service, name, folder_id)
+
+    if existing_id:
+        logger.info(f"Updating existing file: {name} (id: {existing_id})")
+        file = service.files().update(
+            fileId=existing_id,
+            media_body=media,
+        ).execute()
+    else:
+        logger.info(f"Uploading new file: {name}")
+        metadata = {
+            'name': name,
+            'parents': [folder_id],
+        }
+        file = service.files().create(
+            body=metadata,
+            media_body=media,
+            fields='id, name, webViewLink',
+        ).execute()
+
+    logger.info(f"Done! File ID: {file.get('id')}")
+    web_link = file.get('webViewLink')
+    if web_link:
+        logger.info(f"Link: {web_link}")
+    return file
+
+
+def main():
+    if len(sys.argv) < 2:
+        logger.error("Usage: upload_gdrive.py <pdf_path>")
+        sys.exit(1)
+
+    pdf_path = sys.argv[1]
+    if not os.path.exists(pdf_path):
+        logger.error(f"File not found: {pdf_path}")
+        sys.exit(1)
+
+    secrets = load_secrets()
+    if not secrets['client_secret'] or not secrets['folder_id']:
+        sys.exit(1)
+
+    service = get_drive_service(secrets['client_secret'])
+    upload_file(service, pdf_path, secrets['folder_id'])
+    logger.info("Success!")
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/jp-it-news-summary/SKILL.md
+++ b/.claude/skills/jp-it-news-summary/SKILL.md
@@ -63,7 +63,7 @@ rm -f tmp/jp_raw_articles.json tmp/jp_summarized_articles.json
 まず、必要なパッケージがインストールされているか確認してください：
 
 ```bash
-pip install requests beautifulsoup4 feedparser reportlab fake-useragent
+pip install requests beautifulsoup4 feedparser reportlab fake-useragent google-api-python-client google-auth google-auth-oauthlib
 ```
 
 ### 3. ニュースソースの読み込み
@@ -123,6 +123,16 @@ PDFファイルのパスとサマリーをSlackに投稿してください：
 ```bash
 ./.claude/skills/jp-it-news-summary/scripts/post_slack.py output/jp-it-news-YYYY-MM-DD.pdf "本日の国内ITニュース要約です"
 ```
+
+### 8. Google Driveアップロード
+
+PDFファイルを Google Drive の指定フォルダにアップロードしてください：
+
+```bash
+./.claude/skills/jp-it-news-summary/scripts/upload_gdrive.py output/jp-it-news-YYYY-MM-DD.pdf
+```
+
+**注意**: Google Drive の認証情報 (OAuth クライアントシークレットのパス、フォルダ ID) は `config/secrets.json` または環境変数で設定してください。初回実行時はブラウザで Google アカウント認証が必要です。同名ファイルが既に存在する場合は上書きされます。
 
 ## 出力
 

--- a/.claude/skills/jp-it-news-summary/SKILL.md
+++ b/.claude/skills/jp-it-news-summary/SKILL.md
@@ -132,7 +132,7 @@ PDFファイルを Google Drive の指定フォルダにアップロードして
 ./.claude/skills/jp-it-news-summary/scripts/upload_gdrive.py output/jp-it-news-YYYY-MM-DD.pdf
 ```
 
-**注意**: Google Drive の認証情報 (OAuth クライアントシークレットのパス、フォルダ ID) は `config/secrets.json` または環境変数で設定してください。初回実行時はブラウザで Google アカウント認証が必要です。同名ファイルが既に存在する場合は上書きされます。
+**注意**: Google Drive の認証情報 (OAuth クライアントシークレットのパス、フォルダ ID) は `secrets/settings.json` または環境変数で設定してください。初回実行時はブラウザで Google アカウント認証が必要です。同名ファイルが既に存在する場合は上書きされます。
 
 ## 出力
 
@@ -142,7 +142,7 @@ PDFファイルを Google Drive の指定フォルダにアップロードして
 ## トラブルシューティング
 
 - PDFのフォントが表示されない場合: macOS以外の環境では `generate_pdf.py` 内のフォントパスを変更してください
-- Slack投稿が失敗する場合: `config/secrets.json` の設定を確認してください
+- Slack投稿が失敗する場合: `secrets/settings.json` の設定を確認してください
 
 ## 補足事項
 

--- a/.claude/skills/jp-it-news-summary/config/secrets.example.json
+++ b/.claude/skills/jp-it-news-summary/config/secrets.example.json
@@ -1,7 +1,0 @@
-{
-  "slack_bot_token": "xoxb-your-bot-token-here",
-  "slack_webhook_url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
-  "slack_channel_id": "C0XXXXXXXXX",
-  "gdrive_client_secret": "secret/client_secret.apps.googleusercontent.com.json",
-  "gdrive_folder_id": "YOUR_GOOGLE_DRIVE_FOLDER_ID"
-}

--- a/.claude/skills/jp-it-news-summary/config/secrets.example.json
+++ b/.claude/skills/jp-it-news-summary/config/secrets.example.json
@@ -1,5 +1,7 @@
 {
   "slack_bot_token": "xoxb-your-bot-token-here",
   "slack_webhook_url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
-  "slack_channel_id": "C0XXXXXXXXX"
+  "slack_channel_id": "C0XXXXXXXXX",
+  "gdrive_client_secret": "secret/client_secret.apps.googleusercontent.com.json",
+  "gdrive_folder_id": "YOUR_GOOGLE_DRIVE_FOLDER_ID"
 }

--- a/.claude/skills/jp-it-news-summary/scripts/upload_gdrive.py
+++ b/.claude/skills/jp-it-news-summary/scripts/upload_gdrive.py
@@ -1,0 +1,165 @@
+#!/Users/tamaco/Desktop/work/general/.venv/bin/python3
+"""Google Driveアップロードスクリプト（AWSブログ用）"""
+
+import json
+import logging
+import os
+import sys
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+
+# ロギング設定
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s: %(message)s',
+    stream=sys.stderr
+)
+logger = logging.getLogger(__name__)
+
+# パス設定
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(SCRIPT_DIR)
+SECRETS_PATH = os.path.join(SKILL_DIR, 'config', 'secrets.json')
+
+SCOPES = ['https://www.googleapis.com/auth/drive.file']
+
+
+def _load_json(path, default=None):
+    """JSONファイルを読み込む"""
+    if not os.path.exists(path):
+        return default or {}
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        logger.warning(f"{path}: {e}")
+        return default or {}
+
+
+def _get_env_or(key, default=''):
+    """環境変数を取得、なければデフォルト"""
+    return os.environ.get(key) or default
+
+
+def load_secrets():
+    """秘匿情報を読み込む（環境変数優先）"""
+    if not os.path.exists(SECRETS_PATH):
+        logger.warning(f"{SECRETS_PATH} not found. Using environment variables.")
+    secrets = _load_json(SECRETS_PATH)
+    result = {
+        'client_secret': _get_env_or(
+            'GDRIVE_CLIENT_SECRET',
+            secrets.get('gdrive_client_secret', '')
+        ),
+        'folder_id': _get_env_or(
+            'GDRIVE_FOLDER_ID',
+            secrets.get('gdrive_folder_id', '')
+        ),
+    }
+    if not result['client_secret']:
+        logger.error("Google Drive OAuth client secret is not configured.")
+        logger.error(f"  Set GDRIVE_CLIENT_SECRET env var or")
+        logger.error(f"  add gdrive_client_secret to {SECRETS_PATH}")
+    if not result['folder_id']:
+        logger.error("Google Drive folder ID is not configured.")
+        logger.error(f"  Set GDRIVE_FOLDER_ID env var or")
+        logger.error(f"  add gdrive_folder_id to {SECRETS_PATH}")
+    return result
+
+
+def get_drive_service(client_secret_path):
+    """OAuth 2.0認証でGoogle Drive APIサービスを構築"""
+    token_path = os.path.join(os.path.dirname(client_secret_path), 'gdrive_token.json')
+    creds = None
+
+    # 保存済みトークンがあれば読み込む
+    if os.path.exists(token_path):
+        creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+
+    # トークンがない or 期限切れの場合
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            logger.info("Refreshing access token...")
+            creds.refresh(Request())
+        else:
+            logger.info("Opening browser for authorization...")
+            flow = InstalledAppFlow.from_client_secrets_file(client_secret_path, SCOPES)
+            creds = flow.run_local_server(port=0)
+
+        # トークンを保存
+        with open(token_path, 'w') as f:
+            f.write(creds.to_json())
+        logger.info(f"Token saved to {token_path}")
+
+    return build('drive', 'v3', credentials=creds)
+
+
+def find_existing_file(service, name, folder_id):
+    """フォルダ内の同名ファイルを検索"""
+    query = (
+        f"name = '{name}' and '{folder_id}' in parents and trashed = false"
+    )
+    results = service.files().list(
+        q=query, fields='files(id, name)', pageSize=1
+    ).execute()
+    files = results.get('files', [])
+    return files[0]['id'] if files else None
+
+
+def upload_file(service, path, folder_id):
+    """ファイルをGoogle Driveにアップロード（同名ファイルがあれば上書き）"""
+    name = os.path.basename(path)
+    media = MediaFileUpload(path, mimetype='application/pdf', resumable=True)
+
+    existing_id = find_existing_file(service, name, folder_id)
+
+    if existing_id:
+        logger.info(f"Updating existing file: {name} (id: {existing_id})")
+        file = service.files().update(
+            fileId=existing_id,
+            media_body=media,
+        ).execute()
+    else:
+        logger.info(f"Uploading new file: {name}")
+        metadata = {
+            'name': name,
+            'parents': [folder_id],
+        }
+        file = service.files().create(
+            body=metadata,
+            media_body=media,
+            fields='id, name, webViewLink',
+        ).execute()
+
+    logger.info(f"Done! File ID: {file.get('id')}")
+    web_link = file.get('webViewLink')
+    if web_link:
+        logger.info(f"Link: {web_link}")
+    return file
+
+
+def main():
+    if len(sys.argv) < 2:
+        logger.error("Usage: upload_gdrive.py <pdf_path>")
+        sys.exit(1)
+
+    pdf_path = sys.argv[1]
+    if not os.path.exists(pdf_path):
+        logger.error(f"File not found: {pdf_path}")
+        sys.exit(1)
+
+    secrets = load_secrets()
+    if not secrets['client_secret'] or not secrets['folder_id']:
+        sys.exit(1)
+
+    service = get_drive_service(secrets['client_secret'])
+    upload_file(service, pdf_path, secrets['folder_id'])
+    logger.info("Success!")
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/report-email/SKILL.md
+++ b/.claude/skills/report-email/SKILL.md
@@ -16,7 +16,7 @@ Gmail SMTPを使用するには、Googleアカウントでアプリパスワー�
 1. [Googleアカウント](https://myaccount.google.com/) にアクセス
 2. 「セキュリティ」→「2段階認証プロセス」を有効化
 3. 「アプリパスワード」を選択し、新しいパスワードを生成
-4. 生成された16桁のパスワードを `config/secrets.json` に設定
+4. 生成された16桁のパスワードを `secrets/settings.json` に設定
 
 **注意**: 通常のGoogleパスワードではSMTP認証はできません。必ずアプリパスワードを使用してください。
 
@@ -92,7 +92,7 @@ Gmail SMTPを使用するには、Googleアカウントでアプリパスワー�
 
 ## 設定リファレンス
 
-### config/secrets.json
+### secrets/settings.json (skills.report-email)
 
 | キー                | 説明                                          |
 | ------------------- | --------------------------------------------- |
@@ -140,5 +140,5 @@ Gmail SMTPを使用するには、Googleアカウントでアプリパスワー�
 
 ## セキュリティ上の注意
 
-- `secrets.json` はGitにコミットしないでください（`.gitignore` に追加推奨）
+- `secrets/` ディレクトリは `.gitignore` で管理対象外です
 - アプリパスワードは定期的に更新することを推奨します

--- a/.claude/skills/report-email/config/secrets.example.json
+++ b/.claude/skills/report-email/config/secrets.example.json
@@ -1,7 +1,0 @@
-{
-  "smtp_server": "smtp.gmail.com",
-  "smtp_port": 587,
-  "sender_email": "your-email@gmail.com",
-  "sender_password": "your-app-password-here",
-  "sender_name": "Report Sender"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,7 @@ tmp/
 output/
 daily/
 .venv/
+__pycache__/
 
-secret/
-.claude/skills/ai-news-summary/config/secrets.json
-.claude/skills/jp-it-news-summary/config/secrets.json
-.claude/skills/aws-blog-summary/config/secrets.json
-.claude/skills/report-email/config/secrets.json
+secrets/*
+!secrets/settings.example.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ output/
 daily/
 .venv/
 
-# 秘匿情報
+secret/
 .claude/skills/ai-news-summary/config/secrets.json
 .claude/skills/jp-it-news-summary/config/secrets.json
 .claude/skills/aws-blog-summary/config/secrets.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ python3 -m venv .venv && source .venv/bin/activate && pip install -r requirement
 
 ## Structure
 
-```
+```text
+secret/                        # GCP OAuth クライアントシークレット等（gitignore対象）
 .claude/skills/{skill-name}/
 ├── SKILL.md       # 実行手順・制約（スキル実行時はこれに従う）
 ├── config/        # secrets.json（gitignore対象）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,17 +12,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
 ```
 
-各スキルの `config/secrets.json` にSlack/SMTP認証情報を設定（`secrets.example.json` を参照）。
+`secrets/settings.json` に認証情報を設定 (`settings.example.json` を参照、gitignore 対象)。
 
 ## Structure
 
 ```text
-secret/                        # GCP OAuth クライアントシークレット等（gitignore対象）
 .claude/skills/{skill-name}/
 ├── SKILL.md       # 実行手順・制約（スキル実行時はこれに従う）
-├── config/        # secrets.json（gitignore対象）
 ├── scripts/       # Python スクリプト群
-└── templates/     # カテゴリ定義、PDF/Slack/メールテンプレート
+├── templates/     # カテゴリ定義、PDF/Slack/メールテンプレート
+secrets/                       # 認証情報・OAuth トークン等（gitignore 対象）
+├── settings.json              # 全スキル共通の設定ファイル
+├── client_secret_xxx.json     # GCP OAuth クライアントシークレット
+└── gdrive_token.json          # Google Drive トークン
 ```
 
 ## Skills

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -20,7 +20,3 @@ python3 -m venv .venv && source .venv/bin/activate && pip install -r requirement
 ```
 
 各スキルの `config/secrets.json` に認証情報を設定（`secrets.example.json` を参照）。
-
-## ライセンス
-
-Private

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,8 +1,8 @@
+# Claude Toolbox
+
 [English](README.md)
 
-# Claude Code スキル集
-
-ニュース収集・レポート作成を自動化する Claude Code 用カスタムスキル。
+Claude Code 用の自動化ツール・カスタムスキル集。
 
 ## スキル一覧
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
+# Claude Toolbox
+
 [日本語](README.ja.md)
 
-# Claude Code Skills
-
-Custom skills for Claude Code to automate news aggregation and reporting.
+A collection of automation tools and custom skills for Claude Code.
 
 ## Skills
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,3 @@ python3 -m venv .venv && source .venv/bin/activate && pip install -r requirement
 ```
 
 Configure `config/secrets.json` in each skill directory (refer to `secrets.example.json`).
-
-## License
-
-Private

--- a/secrets/settings.example.json
+++ b/secrets/settings.example.json
@@ -1,0 +1,33 @@
+{
+  "common": {
+    "gdrive_client_secret": "secrets/client_secret_xxx.apps.googleusercontent.com.json"
+  },
+  "skills": {
+    "ai-news-summary": {
+      "slack_bot_token": "xoxb-your-token",
+      "slack_webhook_url": "https://hooks.slack.com/services/xxx/xxx/xxx",
+      "slack_channel_id": "C0XXXXXXXXX",
+      "gdrive_folder_id": "your-folder-id"
+    },
+    "aws-blog-summary": {
+      "slack_bot_token": "xoxb-your-token",
+      "slack_webhook_url": "https://hooks.slack.com/services/xxx/xxx/xxx",
+      "slack_channel_id": "C0XXXXXXXXX",
+      "gdrive_folder_id": "your-folder-id"
+    },
+    "jp-it-news-summary": {
+      "slack_bot_token": "xoxb-your-token",
+      "slack_webhook_url": "https://hooks.slack.com/services/xxx/xxx/xxx",
+      "slack_channel_id": "C0XXXXXXXXX",
+      "gdrive_folder_id": "your-folder-id"
+    },
+    "report-email": {
+      "smtp_server": "smtp.gmail.com",
+      "smtp_port": 587,
+      "sender_email": "your-email@gmail.com",
+      "sender_password": "your-app-password",
+      "sender_name": "Claude AI",
+      "default_recipient": "recipient@example.com"
+    }
+  }
+}


### PR DESCRIPTION
  ## Summary

  - Slack 投稿後に PDF を Google Drive の指定フォルダへアップロードするステップを追加
  - OAuth 2.0 (デスクトップアプリ) による認証で、初回のみブラウザ認証が必要
  - 同名ファイルが既に存在する場合は上書き更新
  - 対象スキル: aws-blog-summary, ai-news-summary, jp-it-news-summary